### PR TITLE
Support for ipv6 - partial patch

### DIFF
--- a/lib/network.js
+++ b/lib/network.js
@@ -16,8 +16,16 @@ var network = function(server) {
 network.prototype.start = function() {
   var self = this;
   this.listeningIps.forEach(function(ip) {
-    const udpSocket = dgram.createSocket('udp4');
-    const dst = new Address(CONSTANTS.TRANSPORT.FAMILY.IPV4, ip, self.listeningPort);
+    let udpSocket, dst, ipType;
+    if (ip.indexOf(':') >= 0) { // ipv6
+      udpSocket = dgram.createSocket('udp6');
+      ipType = CONSTANTS.TRANSPORT.FAMILY.IPV6;
+    }
+    else {
+      udpSocket = dgram.createSocket('udp4');
+      ipType = CONSTANTS.TRANSPORT.FAMILY.IPV4;
+    }
+    dst = new Address(ipType, ip, self.listeningPort);
 
     udpSocket.on('error', function(err) {
       self.debug('FATAL', err);
@@ -25,7 +33,7 @@ network.prototype.start = function() {
 
     udpSocket.on('message', function(udpMessage, rinfo) {
       // shoud detect destination address for dst but https://github.com/nodejs/node/issues/1649
-      const src = new Address(CONSTANTS.TRANSPORT.FAMILY.IPV4, rinfo.address, rinfo.port);
+      const src = new Address(ipType, rinfo.address, rinfo.port);
       const transport = new Transport(CONSTANTS.TRANSPORT.PROTOCOL.UDP, src, dst, udpSocket);
       var msg = new Message(self.server, transport);
       if (msg.read(udpMessage)) {


### PR DESCRIPTION
Several issues mention an EINVAL error that happens with ipv6 addresses. This patch should fix the initialization, but there's still a couple of hardcoded ip4 calls on https://github.com/Atlantis-Software/node-turn/blob/master/lib/allocation.js that I don't understand why they are used, but should be adjusted too. Perhaps the same kind of check on the IP type on relayedAddress?